### PR TITLE
Fix booker: Inherit only from strong parents

### DIFF
--- a/multiverse/booker.go
+++ b/multiverse/booker.go
@@ -46,7 +46,7 @@ func (b *Booker) Book(messageID MessageID) {
 
 func (b *Booker) inheritColor(message *Message) (inheritedColor Color, err error) {
 	inheritedColor = message.Payload
-	for _, colorToInherit := range append(append(make([]Color, 0), b.colorsOfStrongParents(message)...), b.colorsOfWeakParents(message)...) {
+	for _, colorToInherit := range append(make([]Color, 0), b.colorsOfStrongParents(message)...) {
 		if colorToInherit == UndefinedColor {
 			continue
 		}


### PR DESCRIPTION
Even if for now we only use strong parents it's good to fix it for the future. If the colors represent branches, message should not inherit from weak parent. Also it should be possible for weak and strong parents to have different colors