### PR TITLE
Randomize the time until next issuance with poisson

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ var (
 	TPS                     = 100
 	DecelerationFactor      = 1         // The factor to control the speed in the simulation.
 	ConsensusMonitorTick    = 100       // Tick to monitor the consensus, in milliseconds.
-	ReleventValidatorWeight = 0         // The node whose weight * ReleventValidatorWeight <= largestWeight will not issue messages (disabled now)
+	RelevantValidatorWeight = 0         // The node whose weight * ReleventValidatorWeight <= largestWeight will not issue messages (disabled now)
 	IMIF                    = "poisson" // Inter Message Issuing Function for time delay between activity messages: poisson or uniform
 	PayloadLoss             = 0.0       // The payload loss in the network.
 	MinDelay                = 100       // The minimum network delay in ms.

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ var (
 	DecelerationFactor      = 1.0       // The factor to control the speed in the simulation.
 	ConsensusMonitorTick    = 100       // Tick to monitor the consensus, in milliseconds.
 	ReleventValidatorWeight = 0         // The node whose weight * ReleventValidatorWeight <= largestWeight will not issue messages (disabled now)
+	IMIF                    = "poisson" // Inter Message Issuing Function for time delay between activity messages: poisson or uniform
 	PayloadLoss             = 0.0       // The payload loss in the network.
 	MinDelay                = 100       // The minimum network delay in ms.
 	MaxDelay                = 100       // The maximum network delay in ms.

--- a/main.go
+++ b/main.go
@@ -486,7 +486,9 @@ func secureNetwork(testNetwork *network.Network) {
 func startSecurityWorker(peer *network.Peer, band float64) {
 	pace := time.Duration(float64(time.Second) * config.DecelerationFactor / band)
 
+	log.Debug("Peer ID: ", peer.ID, " Pace: ", pace)
 	if pace == time.Duration(0) {
+		log.Warn("Peer ID: ", peer.ID, " has 0 pace!")
 		return
 	}
 	ticker := time.NewTicker(pace)

--- a/main.go
+++ b/main.go
@@ -224,6 +224,12 @@ func dumpConfig(fileName string) {
 	if err != nil {
 		log.Error(err)
 	}
+	if _, err = os.Stat(config.ResultDir); os.IsNotExist(err) {
+		err = os.Mkdir(config.ResultDir, 0700)
+		if err != nil {
+			log.Error(err)
+		}
+	}
 	if ioutil.WriteFile(path.Join(config.ResultDir, fileName), bytes, 0644) != nil {
 		log.Error(err)
 	}

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func parseFlags() {
 	consensusMonitorTickPtr :=
 		flag.Int("consensusMonitorTick", config.ConsensusMonitorTick, "The tick to monitor the consensus, in milliseconds")
 	doubleSpendDelayPtr :=
-		flag.Int("decelerationFactor", config.DoubleSpendDelay, "Delay for issuing double spend transactions. (Seconds)")
+		flag.Int("doubleSpendDelay", config.DoubleSpendDelay, "Delay for issuing double spend transactions. (Seconds)")
 	relevantValidatorWeightPtr :=
 		flag.Int("releventValidatorWeight", config.RelevantValidatorWeight, "The node whose weight * RelevantValidatorWeight <= largestWeight will not issue messages")
 	payloadLoss := flag.Float64("payloadLoss", config.PayloadLoss, "The payload loss percentage")
@@ -118,7 +118,7 @@ func parseFlags() {
 	config.DecelerationFactor = *decelerationFactorPtr
 	config.ConsensusMonitorTick = *consensusMonitorTickPtr
 	config.RelevantValidatorWeight = *relevantValidatorWeightPtr
-  config.DoubleSpendDelay = *doubleSpendDelayPtr
+	config.DoubleSpendDelay = *doubleSpendDelayPtr
 	config.PayloadLoss = *payloadLoss
 	config.MinDelay = *minDelay
 	config.MaxDelay = *maxDelay
@@ -509,7 +509,7 @@ func secureNetwork(testNetwork *network.Network) {
 }
 
 func startSecurityWorker(peer *network.Peer, band float64) {
-	pace := time.Duration(float64(time.Second) * config.DecelerationFactor / band)
+	pace := time.Duration(float64(time.Second) * float64(config.DecelerationFactor) / band)
 
 	log.Debug("Peer ID: ", peer.ID, " Pace: ", pace)
 	if pace == time.Duration(0) {
@@ -522,7 +522,7 @@ func startSecurityWorker(peer *network.Peer, band float64) {
 		select {
 		case <-ticker.C:
 			if config.IMIF == "poisson" {
-				pace = time.Duration(float64(time.Second) * config.DecelerationFactor * rand.ExpFloat64() / band)
+				pace = time.Duration(float64(time.Second) * float64(config.DecelerationFactor) * rand.ExpFloat64() / band)
 				if pace > 0 {
 					ticker.Reset(pace)
 				}


### PR DESCRIPTION
Add config that allows for using poisson to model time between next activity messages.
Add creation folder for results if not exists