### PR TITLE
Log the the neighbor count

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,8 @@ var (
 	SimulationStopThreshold = 1.0       // Stop the simulation when > SimulationStopThreshold * NodesCount have reached the same opinion.
 	SimulationTarget        = "CT"      // The simulation target, CT: Confirmation Time, DS: Double Spending
 	ResultDir               = "results" // Path where all the result files will be saved
+	RandomnessWS            = 1.0       // WattsStrogatz randomness parameter, gamma parameter described in https://blog.iota.org/the-fast-probabilistic-consensus-simulator-d5963c558b6e/
+	NeighbourCountWS        = 8         // Number of neighbors node is connected to in WattsStrogatz network topology
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -94,14 +94,26 @@ func parseFlags() {
 		flag.Int("doubleSpendDelay", config.DoubleSpendDelay, "Delay for issuing double spend transactions. (Seconds)")
 	relevantValidatorWeightPtr :=
 		flag.Int("releventValidatorWeight", config.RelevantValidatorWeight, "The node whose weight * RelevantValidatorWeight <= largestWeight will not issue messages")
-	payloadLoss := flag.Float64("payloadLoss", config.PayloadLoss, "The payload loss percentage")
-	minDelay := flag.Int("minDelay", config.MinDelay, "The minimum network delay in ms")
-	maxDelay := flag.Int("maxDelay", config.MaxDelay, "The maximum network delay in ms")
-	deltaURTS := flag.Float64("deltaURTS", config.DeltaURTS, "in seconds, reference: https://iota.cafe/t/orphanage-with-restricted-urts/1199")
-	simulationStopThreshold := flag.Float64("simulationStopThreshold", config.SimulationStopThreshold, "Stop the simulation when >= SimulationStopThreshold * NodesCount have reached the same opinion")
-	simulationTarget := flag.String("simulationTarget", config.SimulationTarget, "The simulation target, CT: Confirmation Time, DS: Double Spending")
-	resultDirPtr := flag.String("resultDir", config.ResultDir, "Directory where the results will be stored")
-	imif := flag.String("IMIF", config.IMIF, "Inter Message Issuing Function for time delay between activity messages: poisson or uniform")
+	payloadLoss :=
+		flag.Float64("payloadLoss", config.PayloadLoss, "The payload loss percentage")
+	minDelay :=
+		flag.Int("minDelay", config.MinDelay, "The minimum network delay in ms")
+	maxDelay :=
+		flag.Int("maxDelay", config.MaxDelay, "The maximum network delay in ms")
+	deltaURTS :=
+		flag.Float64("deltaURTS", config.DeltaURTS, "in seconds, reference: https://iota.cafe/t/orphanage-with-restricted-urts/1199")
+	simulationStopThreshold :=
+		flag.Float64("simulationStopThreshold", config.SimulationStopThreshold, "Stop the simulation when >= SimulationStopThreshold * NodesCount have reached the same opinion")
+	simulationTarget :=
+		flag.String("simulationTarget", config.SimulationTarget, "The simulation target, CT: Confirmation Time, DS: Double Spending")
+	resultDirPtr :=
+		flag.String("resultDir", config.ResultDir, "Directory where the results will be stored")
+	imif :=
+		flag.String("IMIF", config.IMIF, "Inter Message Issuing Function for time delay between activity messages: poisson or uniform")
+	randomnessWS :=
+		flag.Float64("WattsStrogatzRandomness", config.RandomnessWS, "WattsStrogatz randomness parameter")
+	neighbourCountWS :=
+		flag.Int("WattsStrogatzNeighborCount", config.NeighbourCountWS, "Number of neighbors node is connected to in WattsStrogatz network topology")
 
 	// Parse the flags
 	flag.Parse()
@@ -127,6 +139,8 @@ func parseFlags() {
 	config.SimulationTarget = *simulationTarget
 	config.ResultDir = *resultDirPtr
 	config.IMIF = *imif
+	config.RandomnessWS = *randomnessWS
+	config.NeighbourCountWS = *neighbourCountWS
 
 	log.Info("Current configuration:")
 	log.Info("NodesCount: ", config.NodesCount)
@@ -149,6 +163,8 @@ func parseFlags() {
 	log.Info("SimulationTarget:", config.SimulationTarget)
 	log.Info("ResultDir:", config.ResultDir)
 	log.Info("IMIF: ", config.IMIF)
+	log.Info("WattsStrogatzRandomness: ", config.RandomnessWS)
+	log.Info("WattsStrogatzNeighborCount: ", config.NeighbourCountWS)
 
 }
 
@@ -163,7 +179,7 @@ func main() {
 		network.Delay(time.Duration(config.DecelerationFactor)*time.Duration(config.MinDelay)*time.Millisecond,
 			time.Duration(config.DecelerationFactor)*time.Duration(config.MaxDelay)*time.Millisecond),
 		network.PacketLoss(0, config.PayloadLoss),
-		network.Topology(network.WattsStrogatz(4, 1)),
+		network.Topology(network.WattsStrogatz(config.NeighbourCountWS, config.RandomnessWS)),
 	)
 	testNetwork.Start()
 	defer testNetwork.Shutdown()

--- a/network/network.go
+++ b/network/network.go
@@ -186,7 +186,10 @@ func WattsStrogatz(meanDegree int, randomness float64) PeeringStrategy {
 			}
 		}
 
+		totalNeighborCount := 0
 		for sourceNodeID, targetNodeIDs := range graph {
+			log.Debugf("Peer: %s: Number of neighbors: %d", network.Peers[sourceNodeID], len(targetNodeIDs))
+			totalNeighborCount += len(targetNodeIDs)
 			for targetNodeID := range targetNodeIDs {
 				randomNetworkDelay := configuration.RandomNetworkDelay()
 				randomPacketLoss := configuration.RandomPacketLoss()
@@ -206,6 +209,7 @@ func WattsStrogatz(meanDegree int, randomness float64) PeeringStrategy {
 				log.Debugf("Connecting %s <-> %s [network delay (%s), packet loss (%0.4f%%)] ... [DONE]", network.Peers[sourceNodeID], network.Peers[targetNodeID], randomNetworkDelay, randomPacketLoss*100)
 			}
 		}
+		log.Infof("Average number of neighbors: %.1f", float64(totalNeighborCount)/float64(nodeCount))
 	}
 }
 


### PR DESCRIPTION
Note that in the `WattsStrogatz(meanDegree int, randomness float64)`, the `meanDegree` is the `neighbor_count`/2, and the `randomness` is gamma, which is described [here](https://blog.iota.org/the-fast-probabilistic-consensus-simulator-d5963c558b6e/).

- Log the average neighbor count
- Log the neighbor count for each node