### PR TITLE
Adversary analysis

### DIFF
--- a/adversary/adversary_node.go
+++ b/adversary/adversary_node.go
@@ -2,6 +2,26 @@ package adversary
 
 import (
 	"github.com/iotaledger/multivers-simulation/logger"
+	"github.com/iotaledger/multivers-simulation/multiverse"
+	"github.com/iotaledger/multivers-simulation/network"
+	"reflect"
 )
 
 var log = logger.New("Adversary")
+
+type NodeInterface interface {
+	AssignColor(color multiverse.Color)
+}
+
+func CastAdversary(node network.Node) NodeInterface {
+	s := reflect.ValueOf(node)
+	switch s.Interface().(type) {
+	case *ShiftingOpinionNode:
+		return node.(*ShiftingOpinionNode)
+	case *SameOpinionNode:
+		return node.(*SameOpinionNode)
+	}
+	return nil
+}
+
+// TODO implement honest node to reuse some adversary logic and use adversary node interface

--- a/adversary/adversary_node.go
+++ b/adversary/adversary_node.go
@@ -1,12 +1,7 @@
 package adversary
 
 import (
-	"github.com/iotaledger/multivers-simulation/multiverse"
-	"github.com/iotaledger/multivers-simulation/network"
+	"github.com/iotaledger/multivers-simulation/logger"
 )
 
-type Node struct {
-	Peer    *network.Peer
-	Tangle  *multiverse.Tangle
-	AdvType network.AdversaryType
-}
+var log = logger.New("Adversary")

--- a/adversary/adversary_node.go
+++ b/adversary/adversary_node.go
@@ -1,0 +1,68 @@
+package adversary
+
+import (
+	"github.com/iotaledger/multivers-simulation/config"
+	"github.com/iotaledger/multivers-simulation/multiverse"
+	"github.com/iotaledger/multivers-simulation/network"
+	"time"
+)
+
+type Node struct {
+	Peer    *network.Peer
+	Tangle  *multiverse.Tangle
+	AdvType Type
+}
+
+type Type int
+
+const (
+	HonestOpinion Type = iota
+	ShiftOpinion
+	TheSameOpinion
+)
+
+func ToType(adv int) Type {
+	switch adv {
+	case ShiftOpinion:
+		return ShiftOpinion
+	case TheSameOpinion:
+		return TheSameOpinion
+	default:
+		return HonestOpinion
+	}
+}
+
+type Groups []*Group
+
+type Group struct {
+	NodeIDs       []int
+	GroupMana     float64
+	TargetMana    float64
+	Delay         time.Duration
+	AdversaryType Type
+}
+
+func NewGroups() (groups Groups) {
+	groups = make(Groups, 0, len(config.AdversaryTypes))
+	for i, configAdvType := range config.AdversaryTypes {
+		// -1 indicates that there is no target mana provided, adversary will be selected randomly
+		targetMana := float64(-1)
+		delay := config.MinDelay
+
+		if len(config.AdversaryMana) > 0 {
+			targetMana = config.AdversaryMana[i]
+		}
+
+		if len(config.AdversaryDelays) > 0 {
+			delay = config.AdversaryDelays[i]
+		}
+
+		groups = append(groups, &Group{
+			NodeIDs:       make([]int, 0),
+			TargetMana:    targetMana,
+			Delay:         time.Millisecond * time.Duration(delay),
+			AdversaryType: ToType(configAdvType),
+		})
+	}
+	return
+}

--- a/adversary/adversary_node.go
+++ b/adversary/adversary_node.go
@@ -1,68 +1,12 @@
 package adversary
 
 import (
-	"github.com/iotaledger/multivers-simulation/config"
 	"github.com/iotaledger/multivers-simulation/multiverse"
 	"github.com/iotaledger/multivers-simulation/network"
-	"time"
 )
 
 type Node struct {
 	Peer    *network.Peer
 	Tangle  *multiverse.Tangle
-	AdvType Type
-}
-
-type Type int
-
-const (
-	HonestOpinion Type = iota
-	ShiftOpinion
-	TheSameOpinion
-)
-
-func ToType(adv int) Type {
-	switch adv {
-	case ShiftOpinion:
-		return ShiftOpinion
-	case TheSameOpinion:
-		return TheSameOpinion
-	default:
-		return HonestOpinion
-	}
-}
-
-type Groups []*Group
-
-type Group struct {
-	NodeIDs       []int
-	GroupMana     float64
-	TargetMana    float64
-	Delay         time.Duration
-	AdversaryType Type
-}
-
-func NewGroups() (groups Groups) {
-	groups = make(Groups, 0, len(config.AdversaryTypes))
-	for i, configAdvType := range config.AdversaryTypes {
-		// -1 indicates that there is no target mana provided, adversary will be selected randomly
-		targetMana := float64(-1)
-		delay := config.MinDelay
-
-		if len(config.AdversaryMana) > 0 {
-			targetMana = config.AdversaryMana[i]
-		}
-
-		if len(config.AdversaryDelays) > 0 {
-			delay = config.AdversaryDelays[i]
-		}
-
-		groups = append(groups, &Group{
-			NodeIDs:       make([]int, 0),
-			TargetMana:    targetMana,
-			Delay:         time.Millisecond * time.Duration(delay),
-			AdversaryType: ToType(configAdvType),
-		})
-	}
-	return
+	AdvType network.AdversaryType
 }

--- a/adversary/same_opinion.go
+++ b/adversary/same_opinion.go
@@ -1,0 +1,63 @@
+package adversary
+
+import (
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/multivers-simulation/multiverse"
+)
+
+// region ShiftingOpinionNode ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+type SameOpinionNode struct {
+	*multiverse.Node
+}
+
+func NewSameOpinionNode() interface{} {
+	node := multiverse.NewNode().(*multiverse.Node)
+	shiftingNode := &SameOpinionNode{
+		node,
+	}
+	shiftingNode.setupOpinionManager()
+	return shiftingNode
+
+}
+
+func (s *SameOpinionNode) setupOpinionManager() {
+	om := s.Tangle().OpinionManager
+	s.Tangle().OpinionManager = NewShiftingOpinionManager(om)
+	s.Tangle().OpinionManager.Setup()
+}
+
+func (s *SameOpinionNode) AssignColor(color multiverse.Color) {
+	s.Tangle().OpinionManager.SetOpinion(color)
+}
+
+type SameOpinionManager struct {
+	*multiverse.OpinionManager
+}
+
+func NewSameOpinionManager(om multiverse.OpinionManagerInterface) *SameOpinionManager {
+	return &SameOpinionManager{
+		om.(*multiverse.OpinionManager),
+	}
+}
+
+func (sm *SameOpinionManager) FormOpinion(messageID multiverse.MessageID) {
+	defer sm.Events().OpinionFormed.Trigger(messageID)
+
+	if updated := sm.UpdateWeights(messageID); !updated {
+		return
+	}
+
+	sm.weightsUpdated()
+}
+
+func (sm *SameOpinionManager) weightsUpdated() {
+	// do nothing
+}
+
+func (sm *SameOpinionManager) Setup() {
+	sm.Tangle().Booker.Events.MessageBooked.Detach(events.NewClosure(sm.OpinionManager.FormOpinion))
+	sm.Tangle().Booker.Events.MessageBooked.Attach(events.NewClosure(sm.FormOpinion))
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/adversary/shifting_opinion.go
+++ b/adversary/shifting_opinion.go
@@ -61,7 +61,7 @@ func (sm *ShiftingOpinionManager) weightsUpdated() {
 	newOpinion := sm.getMaxOpinion(aw)
 
 	if oldOpinion := sm.Opinion(); newOpinion != oldOpinion {
-		sm.Events().OpinionChanged.Trigger(oldOpinion, newOpinion)
+		sm.Events().OpinionChanged.Trigger(oldOpinion, newOpinion, int64(sm.Tangle().WeightDistribution.Weight(sm.Tangle().Peer.ID)))
 	}
 }
 

--- a/adversary/shifting_opinion.go
+++ b/adversary/shifting_opinion.go
@@ -1,0 +1,65 @@
+package adversary
+
+import (
+	"fmt"
+	"github.com/iotaledger/multivers-simulation/multiverse"
+)
+
+// region HonestNode ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+type HonestNode struct {
+	*multiverse.Node
+}
+
+func (h *HonestNode) SetupOpinionManager() {
+	// no change in behavior of honest node's opinion manager
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region ShiftingOpinionNode ///////////////////////////////////////////////////////////////////////////////////////////////////
+
+type ShiftingOpinionNode struct {
+	*multiverse.Node
+}
+
+func NewShiftingOpinionNode() interface{} {
+	node := multiverse.NewNode().(*multiverse.Node)
+	return &ShiftingOpinionNode{
+		node,
+	}
+
+}
+
+func (s *ShiftingOpinionNode) SetupOpinionManager() {
+	om := s.Tangle().OpinionManager
+	s.Tangle().OpinionManager = NewShiftingOpinionManager(om)
+}
+
+type ShiftingOpinionManager struct {
+	*multiverse.OpinionManager
+}
+
+func NewShiftingOpinionManager(om multiverse.OpinionManagerInterface) *ShiftingOpinionManager {
+	return &ShiftingOpinionManager{
+		om.(*multiverse.OpinionManager),
+	}
+}
+
+func (sm *ShiftingOpinionManager) WeightsUpdated() {
+	maxApprovalWeight := uint64(0)
+	maxOpinion := multiverse.UndefinedColor
+	for color, approvalWeight := range sm.ApprovalWeights() {
+		if approvalWeight > maxApprovalWeight || approvalWeight == maxApprovalWeight && color < maxOpinion {
+			maxApprovalWeight = approvalWeight
+			maxOpinion = color
+		}
+	}
+
+	if oldOpinion := sm.Opinion(); maxOpinion != oldOpinion {
+		sm.Events().OpinionChanged.Trigger(oldOpinion, oldOpinion)
+	}
+	fmt.Println("I'm shadowed opinion manager")
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/config/config.go
+++ b/config/config.go
@@ -9,20 +9,24 @@ var (
 	WeakTipsRatio           = 0.0 // The ratio of weak tips
 	TSA                     = "URTS"
 	TPS                     = 100
-	DecelerationFactor      = 1         // The factor to control the speed in the simulation.
-	ConsensusMonitorTick    = 100       // Tick to monitor the consensus, in milliseconds.
-	RelevantValidatorWeight = 0         // The node whose weight * ReleventValidatorWeight <= largestWeight will not issue messages (disabled now)
-	IMIF                    = "poisson" // Inter Message Issuing Function for time delay between activity messages: poisson or uniform
-	PayloadLoss             = 0.0       // The payload loss in the network.
-	MinDelay                = 100       // The minimum network delay in ms.
-	MaxDelay                = 100       // The maximum network delay in ms.
-	DoubleSpendDelay        = 20        // Delay after which double spending transactions will be issued. In seconds.
-	DeltaURTS               = 5.0       // in seconds, reference: https://iota.cafe/t/orphanage-with-restricted-urts/1199
-	SimulationStopThreshold = 1.0       // Stop the simulation when > SimulationStopThreshold * NodesCount have reached the same opinion.
-	SimulationTarget        = "CT"      // The simulation target, CT: Confirmation Time, DS: Double Spending
-	ResultDir               = "results" // Path where all the result files will be saved
-	RandomnessWS            = 1.0       // WattsStrogatz randomness parameter, gamma parameter described in https://blog.iota.org/the-fast-probabilistic-consensus-simulator-d5963c558b6e/
-	NeighbourCountWS        = 8         // Number of neighbors node is connected to in WattsStrogatz network topology
+	DecelerationFactor      = 1                 // The factor to control the speed in the simulation.
+	ConsensusMonitorTick    = 100               // Tick to monitor the consensus, in milliseconds.
+	RelevantValidatorWeight = 0                 // The node whose weight * RelevantValidatorWeight <= largestWeight will not issue messages (disabled now)
+	IMIF                    = "poisson"         // Inter Message Issuing Function for time delay between activity messages: poisson or uniform
+	PayloadLoss             = 0.0               // The payload loss in the network.
+	MinDelay                = 100               // The minimum network delay in ms.
+	MaxDelay                = 100               // The maximum network delay in ms.
+	DoubleSpendDelay        = 20                // Delay after which double spending transactions will be issued. In seconds.
+	DeltaURTS               = 5.0               // in seconds, reference: https://iota.cafe/t/orphanage-with-restricted-urts/1199
+	SimulationStopThreshold = 1.0               // Stop the simulation when > SimulationStopThreshold * NodesCount have reached the same opinion.
+	SimulationTarget        = "CT"              // The simulation target, CT: Confirmation Time, DS: Double Spending
+	ResultDir               = "results"         // Path where all the result files will be saved
+	RandomnessWS            = 1.0               // WattsStrogatz randomness parameter, gamma parameter described in https://blog.iota.org/the-fast-probabilistic-consensus-simulator-d5963c558b6e/
+	NeighbourCountWS        = 8                 // Number of neighbors node is connected to in WattsStrogatz network topology
+	AdversaryDelays         = []int{50, 200}    // Delays in ms of adversary nodes, eg '50 100 200'
+	AdversaryTypes          = []int{1, 2}       // Defines attack strategy, one of the following: 'shift', 'same'
+	AdversaryMana           = []float64{10, 10} // Adversary nodes mana in %, e.g. '10 10' or 'random' if adversary nodes should be selected randomly
+
 )
 
 var (

--- a/config/config.go
+++ b/config/config.go
@@ -9,24 +9,24 @@ var (
 	WeakTipsRatio           = 0.0 // The ratio of weak tips
 	TSA                     = "URTS"
 	TPS                     = 100
-	DecelerationFactor      = 1                 // The factor to control the speed in the simulation.
-	ConsensusMonitorTick    = 100               // Tick to monitor the consensus, in milliseconds.
-	RelevantValidatorWeight = 0                 // The node whose weight * RelevantValidatorWeight <= largestWeight will not issue messages (disabled now)
-	IMIF                    = "poisson"         // Inter Message Issuing Function for time delay between activity messages: poisson or uniform
-	PayloadLoss             = 0.0               // The payload loss in the network.
-	MinDelay                = 100               // The minimum network delay in ms.
-	MaxDelay                = 100               // The maximum network delay in ms.
-	DoubleSpendDelay        = 20                // Delay after which double spending transactions will be issued. In seconds.
-	DeltaURTS               = 5.0               // in seconds, reference: https://iota.cafe/t/orphanage-with-restricted-urts/1199
-	SimulationStopThreshold = 1.0               // Stop the simulation when > SimulationStopThreshold * NodesCount have reached the same opinion.
-	SimulationTarget        = "CT"              // The simulation target, CT: Confirmation Time, DS: Double Spending
-	ResultDir               = "results"         // Path where all the result files will be saved
-	RandomnessWS            = 1.0               // WattsStrogatz randomness parameter, gamma parameter described in https://blog.iota.org/the-fast-probabilistic-consensus-simulator-d5963c558b6e/
-	NeighbourCountWS        = 8                 // Number of neighbors node is connected to in WattsStrogatz network topology
-	AdversaryDelays         = []int{50, 200}    // Delays in ms of adversary nodes, eg '50 100 200'
-	AdversaryTypes          = []int{1, 2}       // Defines attack strategy, one of the following: 0 - honest node behavior, 1 - shifts opinion, 2 - keeps the same opinion. Max 3 types, one per color.
-	AdversaryMana           = []float64{10, 10} // Adversary nodes mana in %, e.g. '10 10' or leave empty if adversary nodes should be selected randomly, 0 means low mana node, 100 means high mana node
-	AdversaryErrorThreshold = 0.00_00_1         // The error threshold of q - percentage of mana held by adversary
+	DecelerationFactor      = 1                  // The factor to control the speed in the simulation.
+	ConsensusMonitorTick    = 100                // Tick to monitor the consensus, in milliseconds.
+	RelevantValidatorWeight = 0                  // The node whose weight * RelevantValidatorWeight <= largestWeight will not issue messages (disabled now)
+	IMIF                    = "poisson"          // Inter Message Issuing Function for time delay between activity messages: poisson or uniform
+	PayloadLoss             = 0.0                // The payload loss in the network.
+	MinDelay                = 100                // The minimum network delay in ms.
+	MaxDelay                = 100                // The maximum network delay in ms.
+	DoubleSpendDelay        = 20                 // Delay after which double spending transactions will be issued. In seconds.
+	DeltaURTS               = 5.0                // in seconds, reference: https://iota.cafe/t/orphanage-with-restricted-urts/1199
+	SimulationStopThreshold = 1.0                // Stop the simulation when > SimulationStopThreshold * NodesCount have reached the same opinion.
+	SimulationTarget        = "CT"               // The simulation target, CT: Confirmation Time, DS: Double Spending
+	ResultDir               = "results"          // Path where all the result files will be saved
+	RandomnessWS            = 1.0                // WattsStrogatz randomness parameter, gamma parameter described in https://blog.iota.org/the-fast-probabilistic-consensus-simulator-d5963c558b6e/
+	NeighbourCountWS        = 8                  // Number of neighbors node is connected to in WattsStrogatz network topology
+	AdversaryDelays         = []int{50, 200}     // Delays in ms of adversary nodes, eg '50 100 200', SimulationTarget must be 'DS'
+	AdversaryTypes          = []int{1, 1}        // Defines attack strategy, one of the following: 0 - honest node behavior, 1 - shifts opinion, 2 - keeps the same opinion. Max 3 types, one per color. SimulationTarget must be 'DS'
+	AdversaryMana           = []float64{20, 100} // Adversary nodes mana in %, e.g. '10 10' or leave empty if adversary nodes should be selected randomly, 0 means low mana node, 100 means high mana node. SimulationTarget must be 'DS'
+	AdversaryErrorThreshold = 0.00_00_1          // The error threshold of q - percentage of mana held by adversary. SimulationTarget must be 'DS'
 )
 
 var (

--- a/config/config.go
+++ b/config/config.go
@@ -24,9 +24,9 @@ var (
 	RandomnessWS            = 1.0               // WattsStrogatz randomness parameter, gamma parameter described in https://blog.iota.org/the-fast-probabilistic-consensus-simulator-d5963c558b6e/
 	NeighbourCountWS        = 8                 // Number of neighbors node is connected to in WattsStrogatz network topology
 	AdversaryDelays         = []int{50, 200}    // Delays in ms of adversary nodes, eg '50 100 200'
-	AdversaryTypes          = []int{1, 2}       // Defines attack strategy, one of the following: 'shift', 'same'
-	AdversaryMana           = []float64{10, 10} // Adversary nodes mana in %, e.g. '10 10' or 'random' if adversary nodes should be selected randomly
-
+	AdversaryTypes          = []int{1, 2}       // Defines attack strategy, one of the following: 0 - honest node behavior, 1 - shifts opinion, 2 - keeps the same opinion. Max 3 types, one per color.
+	AdversaryMana           = []float64{10, 10} // Adversary nodes mana in %, e.g. '10 10' or leave empty if adversary nodes should be selected randomly, 0 means low mana node, 100 means high mana node
+	AdversaryErrorThreshold = 0.00_00_1         // The error threshold of q - percentage of mana held by adversary
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -130,7 +130,7 @@ func flushWriters(writers []*csv.Writer) {
 
 func dumpConfig(fileName string) {
 	type Configuration struct {
-		NodesCount, NodesTotalWeight, TipsCount, TPS, ConsensusMonitorTick, ReleventValidatorWeight, MinDelay, MaxDelay, DecelerationFactor, DoubleSpendDelay, NeighbourCountWS int
+		NodesCount, NodesTotalWeight, TipsCount, TPS, ConsensusMonitorTick, RelevantValidatorWeight, MinDelay, MaxDelay, DecelerationFactor, DoubleSpendDelay, NeighbourCountWS int
 		ZipfParameter, MessageWeightThreshold, WeakTipsRatio, PayloadLoss, DeltaURTS, SimulationStopThreshold, RandomnessWS, AdversaryErrorThreshold                            float64
 		TSA, ResultDir, IMIF, SimulationTarget                                                                                                                                  string
 		AdversaryDelays, AdversaryTypes                                                                                                                                         []int
@@ -147,7 +147,7 @@ func dumpConfig(fileName string) {
 		TPS:                     config.TPS,
 		DecelerationFactor:      config.DecelerationFactor,
 		ConsensusMonitorTick:    config.ConsensusMonitorTick,
-		ReleventValidatorWeight: config.RelevantValidatorWeight,
+		RelevantValidatorWeight: config.RelevantValidatorWeight,
 		DoubleSpendDelay:        config.DoubleSpendDelay,
 		PayloadLoss:             config.PayloadLoss,
 		MinDelay:                config.MinDelay,

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"encoding/csv"
 	"encoding/json"
-	"flag"
 	"fmt"
+	"github.com/iotaledger/multivers-simulation/simulation"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -71,113 +71,10 @@ var (
 	flipsCounter int
 )
 
-// Parse the flags and update the configuration
-func parseFlags() {
-
-	// Define the configuration flags
-	nodesCountPtr :=
-		flag.Int("nodesCount", config.NodesCount, "The number of nodes")
-	nodesTotalWeightPtr :=
-		flag.Int("nodesTotalWeight", config.NodesTotalWeight, "The total weight of nodes")
-	zipfParameterPtr :=
-		flag.Float64("zipfParameter", config.ZipfParameter, "The zipf's parameter")
-	messageWeightThresholdPtr :=
-		flag.Float64("messageWeightThreshold", config.MessageWeightThreshold, "The messageWeightThreshold of confirmed messages")
-	tipsCountPtr :=
-		flag.Int("tipsCount", config.TipsCount, "The tips count for a message")
-	weakTipsRatioPtr :=
-		flag.Float64("weakTipsRatio", config.WeakTipsRatio, "The ratio of weak tips")
-	tsaPtr :=
-		flag.String("tsa", config.TSA, "The tip selection algorithm")
-	tpsPtr :=
-		flag.Int("tps", config.TPS, "the tips per seconds")
-	decelerationFactorPtr :=
-		flag.Int("decelerationFactor", config.DecelerationFactor, "The factor to control the speed in the simulation")
-	consensusMonitorTickPtr :=
-		flag.Int("consensusMonitorTick", config.ConsensusMonitorTick, "The tick to monitor the consensus, in milliseconds")
-	doubleSpendDelayPtr :=
-		flag.Int("doubleSpendDelay", config.DoubleSpendDelay, "Delay for issuing double spend transactions. (Seconds)")
-	relevantValidatorWeightPtr :=
-		flag.Int("releventValidatorWeight", config.RelevantValidatorWeight, "The node whose weight * RelevantValidatorWeight <= largestWeight will not issue messages")
-	payloadLoss :=
-		flag.Float64("payloadLoss", config.PayloadLoss, "The payload loss percentage")
-	minDelay :=
-		flag.Int("minDelay", config.MinDelay, "The minimum network delay in ms")
-	maxDelay :=
-		flag.Int("maxDelay", config.MaxDelay, "The maximum network delay in ms")
-	deltaURTS :=
-		flag.Float64("deltaURTS", config.DeltaURTS, "in seconds, reference: https://iota.cafe/t/orphanage-with-restricted-urts/1199")
-	simulationStopThreshold :=
-		flag.Float64("simulationStopThreshold", config.SimulationStopThreshold, "Stop the simulation when >= SimulationStopThreshold * NodesCount have reached the same opinion")
-	simulationTarget :=
-		flag.String("simulationTarget", config.SimulationTarget, "The simulation target, CT: Confirmation Time, DS: Double Spending")
-	resultDirPtr :=
-		flag.String("resultDir", config.ResultDir, "Directory where the results will be stored")
-	imif :=
-		flag.String("IMIF", config.IMIF, "Inter Message Issuing Function for time delay between activity messages: poisson or uniform")
-	randomnessWS :=
-		flag.Float64("WattsStrogatzRandomness", config.RandomnessWS, "WattsStrogatz randomness parameter")
-	neighbourCountWS :=
-		flag.Int("WattsStrogatzNeighborCount", config.NeighbourCountWS, "Number of neighbors node is connected to in WattsStrogatz network topology")
-
-	// Parse the flags
-	flag.Parse()
-
-	// Update the configuration parameters
-	config.NodesCount = *nodesCountPtr
-	config.NodesTotalWeight = *nodesTotalWeightPtr
-	config.ZipfParameter = *zipfParameterPtr
-	config.MessageWeightThreshold = *messageWeightThresholdPtr
-	config.TipsCount = *tipsCountPtr
-	config.WeakTipsRatio = *weakTipsRatioPtr
-	config.TSA = *tsaPtr
-	config.TPS = *tpsPtr
-	config.DecelerationFactor = *decelerationFactorPtr
-	config.ConsensusMonitorTick = *consensusMonitorTickPtr
-	config.RelevantValidatorWeight = *relevantValidatorWeightPtr
-	config.DoubleSpendDelay = *doubleSpendDelayPtr
-	config.PayloadLoss = *payloadLoss
-	config.MinDelay = *minDelay
-	config.MaxDelay = *maxDelay
-	config.DeltaURTS = *deltaURTS
-	config.SimulationStopThreshold = *simulationStopThreshold
-	config.SimulationTarget = *simulationTarget
-	config.ResultDir = *resultDirPtr
-	config.IMIF = *imif
-	config.RandomnessWS = *randomnessWS
-	config.NeighbourCountWS = *neighbourCountWS
-
-	log.Info("Current configuration:")
-	log.Info("NodesCount: ", config.NodesCount)
-	log.Info("NodesTotalWeight: ", config.NodesTotalWeight)
-	log.Info("ZipfParameter: ", config.ZipfParameter)
-	log.Info("MessageWeightThreshold: ", config.MessageWeightThreshold)
-	log.Info("TipsCount: ", config.TipsCount)
-	log.Info("WeakTipsRatio: ", config.WeakTipsRatio)
-	log.Info("TSA: ", config.TSA)
-	log.Info("TPS: ", config.TPS)
-	log.Info("DecelerationFactor: ", config.DecelerationFactor)
-	log.Info("ConsensusMonitorTick: ", config.ConsensusMonitorTick)
-	log.Info("RelevantValidatorWeight: ", config.RelevantValidatorWeight)
-	log.Info("DoubleSpendDelay: ", config.DoubleSpendDelay)
-	log.Info("PayloadLoss: ", config.PayloadLoss)
-	log.Info("MinDelay: ", config.MinDelay)
-	log.Info("MaxDelay: ", config.MaxDelay)
-	log.Info("DeltaURTS:", config.DeltaURTS)
-	log.Info("SimulationStopThreshold:", config.SimulationStopThreshold)
-	log.Info("SimulationTarget:", config.SimulationTarget)
-	log.Info("ResultDir:", config.ResultDir)
-	log.Info("IMIF: ", config.IMIF)
-	log.Info("WattsStrogatzRandomness: ", config.RandomnessWS)
-	log.Info("WattsStrogatzNeighborCount: ", config.NeighbourCountWS)
-
-}
-
 func main() {
 	log.Info("Starting simulation ... [DONE]")
 	defer log.Info("Shutting down simulation ... [DONE]")
-
-	parseFlags()
+	simulation.ParseFlags()
 	testNetwork := network.New(
 		network.Nodes(config.NodesCount, multiverse.NewNode, network.ZIPFDistribution(
 			config.ZipfParameter, float64(config.NodesTotalWeight))),

--- a/main.go
+++ b/main.go
@@ -370,14 +370,14 @@ func monitorNetworkState(testNetwork *network.Network) (resultsWriters []*csv.Wr
 
 	go func() {
 		for range dumpingTicker.C {
-			dumpRecords(dsResultsWriter, tpResultsWriter, ccResultsWriter)
+			dumpRecords(dsResultsWriter, tpResultsWriter, ccResultsWriter, honestNodesCount, adversaryNodesCount)
 		}
 	}()
 
 	return
 }
 
-func dumpRecords(dsResultsWriter *csv.Writer, tpResultsWriter *csv.Writer, ccResultsWriter *csv.Writer) {
+func dumpRecords(dsResultsWriter *csv.Writer, tpResultsWriter *csv.Writer, ccResultsWriter *csv.Writer, honestNodesCount int, adversaryNodesCount int) {
 	simulationWg.Add(1)
 	simulationWg.Done()
 

--- a/multiverse/models.go
+++ b/multiverse/models.go
@@ -179,6 +179,21 @@ func (c Color) String() string {
 	}
 }
 
+func ColorFromInt(i int) Color {
+	switch i {
+	case 0:
+		return UndefinedColor
+	case 1:
+		return Blue
+	case 2:
+		return Red
+	case 3:
+		return Green
+	default:
+		return UndefinedColor
+	}
+}
+
 var (
 	UndefinedColor Color
 	Blue           = Color(1)

--- a/multiverse/node.go
+++ b/multiverse/node.go
@@ -9,46 +9,59 @@ import (
 var log = logger.New("Multiverse")
 
 // region Node /////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-type Node struct {
-	Peer   *network.Peer
-	Tangle *Tangle
+type NodeInterface interface {
+	Peer() *network.Peer
+	Tangle() *Tangle
+	IssuePayload(payload Color)
 }
 
-func NewNode() network.Node {
+type Node struct {
+	peer   *network.Peer
+	tangle *Tangle
+}
+
+func NewNode() interface{} {
 	return &Node{
-		Tangle: NewTangle(),
+		tangle: NewTangle(),
 	}
+}
+
+func (n *Node) Peer() *network.Peer {
+	return n.peer
+}
+
+func (n *Node) Tangle() *Tangle {
+	return n.tangle
 }
 
 func (n *Node) Setup(peer *network.Peer, weightDistribution *network.ConsensusWeightDistribution) {
 	defer log.Debugf("%s: Setting up Multiverse ... [DONE]", peer)
 
-	n.Peer = peer
-	n.Tangle.Setup(peer, weightDistribution)
-	n.Tangle.Requester.Events.Request.Attach(events.NewClosure(func(messageID MessageID) {
-		n.Peer.GossipNetworkMessage(&MessageRequest{MessageID: messageID, Issuer: n.Peer.ID})
+	n.peer = peer
+	n.tangle.Setup(peer, weightDistribution)
+	n.tangle.Requester.Events.Request.Attach(events.NewClosure(func(messageID MessageID) {
+		n.peer.GossipNetworkMessage(&MessageRequest{MessageID: messageID, Issuer: n.peer.ID})
 	}))
-	n.Tangle.Booker.Events.MessageBooked.Attach(events.NewClosure(func(messageID MessageID) {
-		n.Peer.GossipNetworkMessage(n.Tangle.Storage.Message(messageID))
+	n.tangle.Booker.Events.MessageBooked.Attach(events.NewClosure(func(messageID MessageID) {
+		n.peer.GossipNetworkMessage(n.tangle.Storage.Message(messageID))
 	}))
 }
 
 // IssuePayload sends the Color to the socket for creating a new Message
 func (n *Node) IssuePayload(payload Color) {
-	n.Peer.Socket <- payload
+	n.peer.Socket <- payload
 }
 
 func (n *Node) HandleNetworkMessage(networkMessage interface{}) {
 	switch receivedNetworkMessage := networkMessage.(type) {
 	case *MessageRequest:
-		if requestedMessage := n.Tangle.Storage.Message(receivedNetworkMessage.MessageID); requestedMessage != nil {
-			n.Peer.Neighbors[receivedNetworkMessage.Issuer].Send(requestedMessage)
+		if requestedMessage := n.tangle.Storage.Message(receivedNetworkMessage.MessageID); requestedMessage != nil {
+			n.peer.Neighbors[receivedNetworkMessage.Issuer].Send(requestedMessage)
 		}
 	case *Message:
-		n.Tangle.ProcessMessage(receivedNetworkMessage)
+		n.tangle.ProcessMessage(receivedNetworkMessage)
 	case Color:
-		n.Tangle.ProcessMessage(n.Tangle.MessageFactory.CreateMessage(receivedNetworkMessage))
+		n.tangle.ProcessMessage(n.tangle.MessageFactory.CreateMessage(receivedNetworkMessage))
 	}
 }
 

--- a/multiverse/opinion_manager.go
+++ b/multiverse/opinion_manager.go
@@ -122,7 +122,6 @@ func (o *OpinionManager) UpdateWeights(messageID MessageID) (updated bool) {
 
 	if !o.colorConfirmed && float64(o.approvalWeights[lastOpinion.Color]) > float64(config.NodesTotalWeight)*config.MessageWeightThreshold {
 		o.colorConfirmed = true
-		o.events.ColorConfirmed.Trigger(lastOpinion.Color)
 		// Here we accumulate the approval weights in our local tangle.
 		o.events.ColorConfirmed.Trigger(lastOpinion.Color, int64(o.tangle.WeightDistribution.Weight(o.tangle.Peer.ID)))
 	}
@@ -140,7 +139,7 @@ func (o *OpinionManager) SetOpinion(opinion Color) {
 
 // Update the opinions counter and ownOpinion based on the highest peer color value and maxApprovalWeight
 // Each Color has approvalWeight. The Color with maxApprovalWeight determines the ownOpinion
-func (o *OpinionManager) WeightsUpdated(peerID network.PeerID) {
+func (o *OpinionManager) WeightsUpdated() {
 	maxApprovalWeight := uint64(0)
 	maxOpinion := UndefinedColor
 	for color, approvalWeight := range o.approvalWeights {
@@ -152,7 +151,7 @@ func (o *OpinionManager) WeightsUpdated(peerID network.PeerID) {
 
 	if oldOpinion := o.ownOpinion; maxOpinion != oldOpinion {
 		o.ownOpinion = maxOpinion
-		o.events.OpinionChanged.Trigger(oldOpinion, maxOpinion, int64(o.tangle.WeightDistribution.Weight(peerID)))
+		o.events.OpinionChanged.Trigger(oldOpinion, maxOpinion, int64(o.tangle.WeightDistribution.Weight(o.tangle.Peer.ID)))
 	}
 }
 

--- a/multiverse/opinion_manager.go
+++ b/multiverse/opinion_manager.go
@@ -14,6 +14,7 @@ type OpinionManagerInterface interface {
 	Setup()
 	FormOpinion(messageID MessageID)
 	Opinion() Color
+	SetOpinion(opinion Color)
 	WeightsUpdated()
 	UpdateWeights(messageID MessageID) (updated bool)
 	Tangle() *Tangle

--- a/multiverse/tangle.go
+++ b/multiverse/tangle.go
@@ -13,7 +13,7 @@ type Tangle struct {
 	ApprovalManager    *ApprovalManager
 	Requester          *Requester
 	Booker             *Booker
-	OpinionManager     *OpinionManager
+	OpinionManager     OpinionManagerInterface
 	TipManager         *TipManager
 	MessageFactory     *MessageFactory
 	Utils              *Utils

--- a/multiverse/tipmanager.go
+++ b/multiverse/tipmanager.go
@@ -56,7 +56,7 @@ func NewTipManager(tangle *Tangle, tsaString string) (tipManager *TipManager) {
 }
 
 func (t *TipManager) Setup() {
-	t.tangle.OpinionManager.Events.OpinionFormed.Attach(events.NewClosure(t.AnalyzeMessage))
+	t.tangle.OpinionManager.Events().OpinionFormed.Attach(events.NewClosure(t.AnalyzeMessage))
 }
 
 func (t *TipManager) AnalyzeMessage(messageID MessageID) {

--- a/multiverse_test/tipmanager_test.go
+++ b/multiverse_test/tipmanager_test.go
@@ -23,7 +23,7 @@ func TestTipManager(t *testing.T) {
 	log.Info("Starting TipManager Test ... [DONE]")
 	defer log.Info("Shutting down TipManager Test ... [DONE]")
 	testNetwork := network.New(
-		network.Nodes(nodeCount, multiverse.NewNode, network.ZIPFDistribution(config.ZipfParameter, float64(config.NodesTotalWeight))),
+		network.Nodes(nodeCount, network.NodeClosure(multiverse.NewNode), network.ZIPFDistribution(config.ZipfParameter, float64(config.NodesTotalWeight))),
 		network.Delay(30*time.Millisecond, 250*time.Millisecond),
 		network.PacketLoss(0, 0.05),
 		network.Topology(network.WattsStrogatz(4, 1)),
@@ -43,7 +43,7 @@ func monitorNetworkState(testNetwork *network.Network) {
 
 	for _, id := range config.MonitoredAWPeers {
 		awPeer := testNetwork.Peers[id]
-		awPeer.Node.(*multiverse.Node).Tangle.ApprovalManager.Events.MessageConfirmed.Attach(
+		awPeer.Node.(multiverse.NodeInterface).Tangle().ApprovalManager.Events.MessageConfirmed.Attach(
 			events.NewClosure(func(message *multiverse.Message, messageMetadata *multiverse.MessageMetadata, weight uint64) {
 				atomic.AddInt64(&confirmedMessageCounter, 1)
 			}))
@@ -52,7 +52,7 @@ func monitorNetworkState(testNetwork *network.Network) {
 	return
 }
 
-func secureNetwork(testNetwork *network.Network, decelerationFactor float64) {
+func secureNetwork(testNetwork *network.Network, decelerationFactor int) {
 	largestWeight := float64(testNetwork.WeightDistribution.LargestWeight())
 
 	for _, peer := range testNetwork.Peers {
@@ -63,7 +63,7 @@ func secureNetwork(testNetwork *network.Network, decelerationFactor float64) {
 		}
 
 		issuingPeriod := float64(config.NodesTotalWeight) / float64(config.TPS) / weightOfPeer
-		pace := time.Duration(issuingPeriod * decelerationFactor * float64(time.Second))
+		pace := time.Duration(issuingPeriod * float64(decelerationFactor) * float64(time.Second))
 		go startSecurityWorker(peer, pace)
 	}
 }

--- a/multiverse_test/tipmanager_test.go
+++ b/multiverse_test/tipmanager_test.go
@@ -22,8 +22,11 @@ var (
 func TestTipManager(t *testing.T) {
 	log.Info("Starting TipManager Test ... [DONE]")
 	defer log.Info("Shutting down TipManager Test ... [DONE]")
+	nodeFactories := map[network.AdversaryType]network.NodeFactory{
+		network.HonestNode: network.NodeClosure(multiverse.NewNode),
+	}
 	testNetwork := network.New(
-		network.Nodes(nodeCount, network.NodeClosure(multiverse.NewNode), network.ZIPFDistribution(config.ZipfParameter, float64(config.NodesTotalWeight))),
+		network.Nodes(nodeCount, nodeFactories, network.ZIPFDistribution(config.ZipfParameter, float64(config.NodesTotalWeight))),
 		network.Delay(30*time.Millisecond, 250*time.Millisecond),
 		network.PacketLoss(0, 0.05),
 		network.Topology(network.WattsStrogatz(4, 1)),

--- a/network/consensus_weight.go
+++ b/network/consensus_weight.go
@@ -3,17 +3,16 @@ package network
 import (
 	"github.com/iotaledger/hive.go/crypto"
 	"github.com/iotaledger/hive.go/datastructure/set"
-	"github.com/iotaledger/multivers-simulation/adversary"
 	"github.com/iotaledger/multivers-simulation/config"
 	"math"
 )
 
-type WeightGenerator func(nodeCount int, adversaryGroups adversary.Groups) []uint64
+type WeightGenerator func(nodeCount int, adversaryGroups AdversaryGroups) []uint64
 
 // region ZIPFDistribution /////////////////////////////////////////////////////////////////////////////////////////////
 
 func ZIPFDistribution(s float64, totalWeight float64) WeightGenerator {
-	return func(nodeCount int, group adversary.Groups) (result []uint64) {
+	return func(nodeCount int, groups AdversaryGroups) (result []uint64) {
 		rawTotalWeight := uint64(0)
 		rawWeights := make([]uint64, nodeCount)
 		for i := 0; i < nodeCount; i++ {
@@ -33,16 +32,17 @@ func ZIPFDistribution(s float64, totalWeight float64) WeightGenerator {
 
 		result[0] += uint64(totalWeight) - normalizedTotalWeight
 
+		// TODO connect to choose index
 		return
 	}
 }
 
-func chooseAdversaryNodes(ZIPFDistribution []uint64, groups adversary.Groups, totalWeight float64, nodeCount int) {
+func chooseAdversaryNodes(ZIPFDistribution []uint64, groups AdversaryGroups, totalWeight float64, nodeCount int) {
 	// are there any adversary groups provided in the configuration?
 	if len(groups) == 0 {
 		return
 	}
-	manaPercentageProvided := make(adversary.Groups, 0)
+	manaPercentageProvided := make(AdversaryGroups, 0)
 	// check if adversary mana target provided
 	for _, group := range groups {
 		switch group.TargetMana {

--- a/network/consensus_weight.go
+++ b/network/consensus_weight.go
@@ -1,13 +1,19 @@
 package network
 
 import (
+	"github.com/iotaledger/hive.go/crypto"
+	"github.com/iotaledger/hive.go/datastructure/set"
+	"github.com/iotaledger/multivers-simulation/adversary"
+	"github.com/iotaledger/multivers-simulation/config"
 	"math"
 )
 
-type WeightGenerator func(nodeCount int) []uint64
+type WeightGenerator func(nodeCount int, adversaryGroups adversary.Groups) []uint64
+
+// region ZIPFDistribution /////////////////////////////////////////////////////////////////////////////////////////////
 
 func ZIPFDistribution(s float64, totalWeight float64) WeightGenerator {
-	return func(nodeCount int) (result []uint64) {
+	return func(nodeCount int, group adversary.Groups) (result []uint64) {
 		rawTotalWeight := uint64(0)
 		rawWeights := make([]uint64, nodeCount)
 		for i := 0; i < nodeCount; i++ {
@@ -30,6 +36,89 @@ func ZIPFDistribution(s float64, totalWeight float64) WeightGenerator {
 		return
 	}
 }
+
+func chooseAdversaryNodes(ZIPFDistribution []uint64, groups adversary.Groups, totalWeight float64, nodeCount int) {
+	// are there any adversary groups provided in the configuration?
+	if len(groups) == 0 {
+		return
+	}
+	manaPercentageProvided := make(adversary.Groups, 0)
+	// check if adversary mana target provided
+	for _, group := range groups {
+		switch group.TargetMana {
+		case 100:
+			idx := selectMaxWeightIndex(ZIPFDistribution)
+			group.NodeIDs = append(group.NodeIDs, idx)
+		case 0:
+			idx := selectMinWeightIndex(ZIPFDistribution)
+			group.NodeIDs = append(group.NodeIDs, idx)
+		case -1:
+			// all weights are chosen randomly
+			for i, idx := range randomWeightIndex(ZIPFDistribution, len(groups)) {
+				groups[i].NodeIDs = append(groups[i].NodeIDs, idx)
+			}
+			return
+		default:
+			group.TargetMana = totalWeight * group.TargetMana / 100
+			manaPercentageProvided = append(manaPercentageProvided, group)
+		}
+	}
+
+	// We define this because the adversary nodes' weights might not exactly occupy totalWeight * q
+	errorThreshold := totalWeight * config.AdversaryErrorThreshold
+
+	for i, v := range ZIPFDistribution[1:] {
+		for _, group := range manaPercentageProvided {
+			if group.GroupMana < group.TargetMana && group.GroupMana+float64(v) < group.TargetMana+errorThreshold {
+				group.GroupMana += float64(v)
+				group.NodeIDs = append(group.NodeIDs, i+1)
+			}
+			log.Infof("Group: %d, Node count: %d, q: %.5f, adNodeList: %v", i, nodeCount,
+				group.GroupMana/totalWeight, group.NodeIDs)
+		}
+	}
+
+	// select randomly
+
+}
+
+func randomWeightIndex(weights []uint64, count int) (randomWeights []int) {
+	selectedPeers := set.New()
+	for len(randomWeights) < count {
+		if randomIndex := crypto.Randomness.Intn(len(weights)); selectedPeers.Add(randomIndex) {
+			randomWeights = append(randomWeights, randomIndex)
+		}
+	}
+	return
+}
+
+func selectMinWeightIndex(x []uint64) int {
+	minLocation := 0
+	currentMin := x[0]
+	for i, v := range x[1:] {
+		if v < currentMin {
+			currentMin = v
+			minLocation = i + 1
+		}
+	}
+	return minLocation
+}
+
+func selectMaxWeightIndex(x []uint64) int {
+	maxLocation := 0
+	currentMax := x[0]
+	for i, v := range x[1:] {
+		if v > currentMax {
+			currentMax = v
+			maxLocation = i + 1
+		}
+	}
+	return maxLocation
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region ConsensusWeightDistribution //////////////////////////////////////////////////////////////////////////////////
 
 type ConsensusWeightDistribution struct {
 	weights       map[PeerID]uint64
@@ -80,3 +169,5 @@ func (c *ConsensusWeightDistribution) rescanForLargestWeight() {
 		}
 	}
 }
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/network/consensus_weight.go
+++ b/network/consensus_weight.go
@@ -1,18 +1,15 @@
 package network
 
 import (
-	"github.com/iotaledger/hive.go/crypto"
-	"github.com/iotaledger/hive.go/datastructure/set"
-	"github.com/iotaledger/multivers-simulation/config"
 	"math"
 )
 
-type WeightGenerator func(nodeCount int, adversaryGroups AdversaryGroups) []uint64
+type WeightGenerator func(nodeCount int) []uint64
 
 // region ZIPFDistribution /////////////////////////////////////////////////////////////////////////////////////////////
 
 func ZIPFDistribution(s float64, totalWeight float64) WeightGenerator {
-	return func(nodeCount int, groups AdversaryGroups) (result []uint64) {
+	return func(nodeCount int) (result []uint64) {
 		rawTotalWeight := uint64(0)
 		rawWeights := make([]uint64, nodeCount)
 		for i := 0; i < nodeCount; i++ {
@@ -32,88 +29,8 @@ func ZIPFDistribution(s float64, totalWeight float64) WeightGenerator {
 
 		result[0] += uint64(totalWeight) - normalizedTotalWeight
 
-		// TODO connect to choose index
 		return
 	}
-}
-
-func chooseAdversaryNodes(ZIPFDistribution []uint64, groups AdversaryGroups, totalWeight float64, nodeCount int) {
-	// are there any adversary groups provided in the configuration?
-	if len(groups) == 0 {
-		return
-	}
-	manaPercentageProvided := make(AdversaryGroups, 0)
-	// check if adversary mana target provided
-	for _, group := range groups {
-		switch group.TargetMana {
-		case 100:
-			idx := selectMaxWeightIndex(ZIPFDistribution)
-			group.NodeIDs = append(group.NodeIDs, idx)
-		case 0:
-			idx := selectMinWeightIndex(ZIPFDistribution)
-			group.NodeIDs = append(group.NodeIDs, idx)
-		case -1:
-			// all weights are chosen randomly
-			for i, idx := range randomWeightIndex(ZIPFDistribution, len(groups)) {
-				groups[i].NodeIDs = append(groups[i].NodeIDs, idx)
-			}
-			return
-		default:
-			group.TargetMana = totalWeight * group.TargetMana / 100
-			manaPercentageProvided = append(manaPercentageProvided, group)
-		}
-	}
-
-	// We define this because the adversary nodes' weights might not exactly occupy totalWeight * q
-	errorThreshold := totalWeight * config.AdversaryErrorThreshold
-
-	for i, v := range ZIPFDistribution[1:] {
-		for _, group := range manaPercentageProvided {
-			if group.GroupMana < group.TargetMana && group.GroupMana+float64(v) < group.TargetMana+errorThreshold {
-				group.GroupMana += float64(v)
-				group.NodeIDs = append(group.NodeIDs, i+1)
-			}
-			log.Infof("Group: %d, Node count: %d, q: %.5f, adNodeList: %v", i, nodeCount,
-				group.GroupMana/totalWeight, group.NodeIDs)
-		}
-	}
-
-	// select randomly
-
-}
-
-func randomWeightIndex(weights []uint64, count int) (randomWeights []int) {
-	selectedPeers := set.New()
-	for len(randomWeights) < count {
-		if randomIndex := crypto.Randomness.Intn(len(weights)); selectedPeers.Add(randomIndex) {
-			randomWeights = append(randomWeights, randomIndex)
-		}
-	}
-	return
-}
-
-func selectMinWeightIndex(x []uint64) int {
-	minLocation := 0
-	currentMin := x[0]
-	for i, v := range x[1:] {
-		if v < currentMin {
-			currentMin = v
-			minLocation = i + 1
-		}
-	}
-	return minLocation
-}
-
-func selectMaxWeightIndex(x []uint64) int {
-	maxLocation := 0
-	currentMax := x[0]
-	for i, v := range x[1:] {
-		if v > currentMax {
-			currentMax = v
-			maxLocation = i + 1
-		}
-	}
-	return maxLocation
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/network/groups.go
+++ b/network/groups.go
@@ -1,14 +1,20 @@
 package network
 
 import (
+	"github.com/iotaledger/hive.go/crypto"
+	"github.com/iotaledger/hive.go/datastructure/queue"
+	"github.com/iotaledger/hive.go/datastructure/set"
+	"github.com/iotaledger/hive.go/types"
 	"github.com/iotaledger/multivers-simulation/config"
 	"time"
 )
 
+// region AdversaryType ////////////////////////////////////////////////////////////////////////////////////////////////
+
 type AdversaryType int
 
 const (
-	HonestOpinion AdversaryType = iota
+	HonestNode AdversaryType = iota
 	ShiftOpinion
 	TheSameOpinion
 )
@@ -20,11 +26,15 @@ func ToType(adv int) AdversaryType {
 	case int(TheSameOpinion):
 		return TheSameOpinion
 	default:
-		return HonestOpinion
+		return HonestNode
 	}
 }
 
-type AdversaryGroups []*AdversaryGroup
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// region AdversaryGroup ////////////////////////////////////////////////////////////////////////////////////////////////
+
+var NodeIDToGroupIndexMap = make(map[int]int)
 
 type AdversaryGroup struct {
 	NodeIDs       []int
@@ -33,6 +43,13 @@ type AdversaryGroup struct {
 	Delay         time.Duration
 	AdversaryType AdversaryType
 }
+
+func (g *AdversaryGroup) AddNodeID(id, groupId int) {
+	g.NodeIDs = append(g.NodeIDs, id)
+	NodeIDToGroupIndexMap[id] = groupId
+}
+
+type AdversaryGroups []*AdversaryGroup
 
 func NewAdversaryGroups() (groups AdversaryGroups) {
 	groups = make(AdversaryGroups, 0, len(config.AdversaryTypes))
@@ -58,3 +75,104 @@ func NewAdversaryGroups() (groups AdversaryGroups) {
 	}
 	return
 }
+
+func (g *AdversaryGroups) ChooseAdversaryNodes(ZIPFDistribution []uint64, totalWeight float64, nodeCount int) {
+	// are there any adversary groups provided in the configuration?
+	if len(*g) == 0 {
+		return
+	}
+	manaPercentageGroupIds := make([]int, 0)
+	usedWeights := make(map[int]types.Empty)
+	// check if adversary mana target is provided
+	for groupIndex, group := range *g {
+		switch group.TargetMana {
+		case 100: // node has max
+			idx := selectMaxWeightIndex(ZIPFDistribution, usedWeights)
+			group.AddNodeID(idx, groupIndex)
+			group.GroupMana = float64(ZIPFDistribution[idx])
+			usedWeights[idx] = types.Void
+		case 0:
+			idx := selectMinWeightIndex(ZIPFDistribution, usedWeights)
+			group.AddNodeID(idx, groupIndex)
+			group.GroupMana = float64(ZIPFDistribution[idx])
+			usedWeights[idx] = types.Void
+		case -1:
+			// all weights are chosen randomly
+			for i, idx := range randomWeightIndex(ZIPFDistribution, len(*g)) {
+				(*g)[i].GroupMana = float64(ZIPFDistribution[idx])
+				(*g)[i].AddNodeID(idx, i)
+			}
+			return
+		default:
+			group.TargetMana = totalWeight * group.TargetMana / 100
+			manaPercentageGroupIds = append(manaPercentageGroupIds, groupIndex)
+		}
+	}
+
+	// We define this because the adversary nodes' weights might not exactly occupy totalWeight * q
+	errorThreshold := totalWeight * config.AdversaryErrorThreshold
+	groupIndexQueue := queue.New(len(manaPercentageGroupIds))
+	// to choose indexes alternately and keep the balance between adversary groups
+	for _, groupIndex := range manaPercentageGroupIds {
+		groupIndexQueue.Offer(groupIndex)
+	}
+	for index, v := range ZIPFDistribution[1:] {
+		for i := 0; i < groupIndexQueue.Size(); i++ {
+			elem, _ := groupIndexQueue.Poll()
+			groupIndex := elem.(int)
+			if (*g)[groupIndex].GroupMana < (*g)[groupIndex].TargetMana && (*g)[groupIndex].GroupMana+float64(v) < (*g)[groupIndex].TargetMana+errorThreshold {
+				(*g)[groupIndex].GroupMana += float64(v)
+				(*g)[groupIndex].AddNodeID(index+1, groupIndex)
+				groupIndexQueue.Offer(groupIndex)
+				break
+			}
+			groupIndexQueue.Offer(groupIndex)
+		}
+	}
+	for groupIndex, group := range *g {
+		log.Infof("GroupId: %d, AdversaryType: %d, Node count: %d, q: %.5f, adNodeList: %v", groupIndex, group.AdversaryType, len(group.NodeIDs),
+			group.GroupMana/totalWeight, group.NodeIDs)
+	}
+}
+
+func randomWeightIndex(weights []uint64, count int) (randomWeights []int) {
+	selectedPeers := set.New()
+	for len(randomWeights) < count {
+		if randomIndex := crypto.Randomness.Intn(len(weights)); selectedPeers.Add(randomIndex) {
+			randomWeights = append(randomWeights, randomIndex)
+		}
+	}
+	return
+}
+
+func selectMinWeightIndex(weights []uint64, usedWeights map[int]types.Empty) int {
+	minLocation := -1
+	currentMin := weights[0]
+	for i, weight := range weights {
+		// skip indexes that has been already used
+		if _, ok := usedWeights[i]; !ok {
+			if weight < currentMin || minLocation == -1 {
+				currentMin = weight
+				minLocation = i
+			}
+		}
+	}
+	return minLocation
+}
+
+func selectMaxWeightIndex(weights []uint64, usedWeights map[int]types.Empty) int {
+	maxLocation := -1
+	currentMax := weights[0]
+	for i, weight := range weights {
+		// skip indexes that has been already used
+		if _, ok := usedWeights[i]; !ok {
+			if weight > currentMax || maxLocation == -1 {
+				currentMax = weight
+				maxLocation = i
+			}
+		}
+	}
+	return maxLocation
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/network/groups.go
+++ b/network/groups.go
@@ -1,0 +1,60 @@
+package network
+
+import (
+	"github.com/iotaledger/multivers-simulation/config"
+	"time"
+)
+
+type AdversaryType int
+
+const (
+	HonestOpinion AdversaryType = iota
+	ShiftOpinion
+	TheSameOpinion
+)
+
+func ToType(adv int) AdversaryType {
+	switch adv {
+	case int(ShiftOpinion):
+		return ShiftOpinion
+	case int(TheSameOpinion):
+		return TheSameOpinion
+	default:
+		return HonestOpinion
+	}
+}
+
+type AdversaryGroups []*AdversaryGroup
+
+type AdversaryGroup struct {
+	NodeIDs       []int
+	GroupMana     float64
+	TargetMana    float64
+	Delay         time.Duration
+	AdversaryType AdversaryType
+}
+
+func NewAdversaryGroups() (groups AdversaryGroups) {
+	groups = make(AdversaryGroups, 0, len(config.AdversaryTypes))
+	for i, configAdvType := range config.AdversaryTypes {
+		// -1 indicates that there is no target mana provided, adversary will be selected randomly
+		targetMana := float64(-1)
+		delay := config.MinDelay
+
+		if len(config.AdversaryMana) > 0 {
+			targetMana = config.AdversaryMana[i]
+		}
+
+		if len(config.AdversaryDelays) > 0 {
+			delay = config.AdversaryDelays[i]
+		}
+
+		groups = append(groups, &AdversaryGroup{
+			NodeIDs:       make([]int, 0),
+			TargetMana:    targetMana,
+			Delay:         time.Millisecond * time.Duration(delay),
+			AdversaryType: ToType(configAdvType),
+		})
+	}
+	return
+}

--- a/network/groups.go
+++ b/network/groups.go
@@ -76,7 +76,7 @@ func NewAdversaryGroups() (groups AdversaryGroups) {
 	return
 }
 
-func (g *AdversaryGroups) ChooseAdversaryNodes(ZIPFDistribution []uint64, totalWeight float64, nodeCount int) {
+func (g *AdversaryGroups) ChooseAdversaryNodes(ZIPFDistribution []uint64, totalWeight float64) {
 	// are there any adversary groups provided in the configuration?
 	if len(*g) == 0 {
 		return
@@ -132,6 +132,17 @@ func (g *AdversaryGroups) ChooseAdversaryNodes(ZIPFDistribution []uint64, totalW
 	for groupIndex, group := range *g {
 		log.Infof("GroupId: %d, AdversaryType: %d, Node count: %d, q: %.5f, adNodeList: %v", groupIndex, group.AdversaryType, len(group.NodeIDs),
 			group.GroupMana/totalWeight, group.NodeIDs)
+	}
+}
+
+func (g *AdversaryGroups) ApplyNetworkDelayForAdversaryNodes(network *Network) {
+	for _, adversaryGroup := range *g {
+		for _, nodeID := range adversaryGroup.NodeIDs {
+			peer := network.Peer(nodeID)
+			for _, neighbor := range peer.Neighbors {
+				neighbor.SetDelay(adversaryGroup.Delay)
+			}
+		}
 	}
 }
 

--- a/network/network.go
+++ b/network/network.go
@@ -99,7 +99,7 @@ func (c *Configuration) CreatePeers(network *Network) {
 	network.WeightDistribution = NewConsensusWeightDistribution()
 	for _, nodesSpecification := range c.nodes {
 		nodeWeights := nodesSpecification.weightGenerator(nodesSpecification.nodeCount)
-		network.AdversaryGroups.ChooseAdversaryNodes(nodeWeights, float64(config.NodesTotalWeight), nodesSpecification.nodeCount)
+		network.AdversaryGroups.ChooseAdversaryNodes(nodeWeights, float64(config.NodesTotalWeight))
 
 		for i := 0; i < nodesSpecification.nodeCount; i++ {
 			nodeType := HonestNode
@@ -124,6 +124,7 @@ func (c *Configuration) ConnectPeers(network *Network) {
 	defer log.Info("Connecting peers ... [DONE]")
 
 	c.peeringStrategy(network, c)
+	network.AdversaryGroups.ApplyNetworkDelayForAdversaryNodes(network)
 }
 
 // endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -172,7 +173,6 @@ func Topology(peeringStrategy PeeringStrategy) Option {
 
 type PeeringStrategy func(network *Network, options *Configuration)
 
-// TODO is it possible to Create AdversaryIncludedPeeringStrategy that will use this peering Strategy... the same for Zipf
 func WattsStrogatz(meanDegree int, randomness float64) PeeringStrategy {
 	if meanDegree%2 != 0 {
 		panic("Invalid argument: meanDegree needs to be even")
@@ -203,7 +203,6 @@ func WattsStrogatz(meanDegree int, randomness float64) PeeringStrategy {
 				}
 			}
 		}
-		// TODO modify it to use network delay provided by the config
 		totalNeighborCount := 0
 		for sourceNodeID, targetNodeIDs := range graph {
 			log.Debugf("Peer: %s: Number of neighbors: %d", network.Peers[sourceNodeID], len(targetNodeIDs))

--- a/network/network.go
+++ b/network/network.go
@@ -25,9 +25,9 @@ func New(option ...Option) (network *Network) {
 		Peers: make([]*Peer, 0),
 	}
 
-	config := NewConfiguration(option...)
-	config.CreatePeers(network)
-	config.ConnectPeers(network)
+	configuration := NewConfiguration(option...)
+	configuration.CreatePeers(network)
+	configuration.ConnectPeers(network)
 
 	return
 }

--- a/network/network.go
+++ b/network/network.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"github.com/iotaledger/multivers-simulation/adversary"
 	"github.com/iotaledger/multivers-simulation/logger"
 	"time"
 
@@ -91,7 +90,7 @@ func (c *Configuration) CreatePeers(network *Network) {
 	defer log.Info("Creating peers ... [DONE]")
 
 	// TODO update node creation based on adversary groups
-	adversaryGroups := adversary.NewGroups()
+	adversaryGroups := NewAdversaryGroups()
 	network.WeightDistribution = NewConsensusWeightDistribution()
 	for _, nodesSpecification := range c.nodes {
 		nodeWeights := nodesSpecification.weightGenerator(nodesSpecification.nodeCount, adversaryGroups)
@@ -124,7 +123,7 @@ func Nodes(nodeCount int, nodeFactories []NodeFactory, weightGenerator WeightGen
 	nodeSpecs := &NodesSpecification{
 		nodeCount:       nodeCount,
 		nodeFactories:   nodeFactories,
-		adversaryGroups: adversary.NewGroups(),
+		adversaryGroups: NewAdversaryGroups(),
 		weightGenerator: weightGenerator,
 	}
 
@@ -136,7 +135,7 @@ func Nodes(nodeCount int, nodeFactories []NodeFactory, weightGenerator WeightGen
 type NodesSpecification struct {
 	nodeCount       int
 	nodeFactories   []NodeFactory
-	adversaryGroups adversary.Groups
+	adversaryGroups AdversaryGroups
 	weightGenerator WeightGenerator
 }
 

--- a/network/node.go
+++ b/network/node.go
@@ -1,8 +1,17 @@
 package network
 
+// region Node /////////////////////////////////////////////////////////////////////////////////////////////////////////
 type Node interface {
 	Setup(peer *Peer, weightDistribution *ConsensusWeightDistribution)
 	HandleNetworkMessage(networkMessage interface{})
 }
 
 type NodeFactory func() Node
+
+func NodeClosure(closure func() interface{}) NodeFactory {
+	return func() Node {
+		return closure().(Node)
+	}
+}
+
+// endregion ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/network/peer.go
+++ b/network/peer.go
@@ -122,6 +122,10 @@ func (c *Connection) Send(message interface{}) {
 	}, c.networkDelay)
 }
 
+func (c *Connection) SetDelay(delay time.Duration) {
+	c.networkDelay = delay
+}
+
 func (c *Connection) Shutdown() {
 	c.shutdownOnce.Do(func() {
 		c.timedExecutor.Shutdown(timedexecutor.CancelPendingTasks)

--- a/simulation/parser.go
+++ b/simulation/parser.go
@@ -1,0 +1,152 @@
+package simulation
+
+import (
+	"flag"
+	"github.com/iotaledger/multivers-simulation/config"
+	"github.com/labstack/gommon/log"
+	"strconv"
+	"strings"
+)
+
+// Parse the flags and update the configuration
+func ParseFlags() {
+
+	// Define the configuration flags
+	nodesCountPtr :=
+		flag.Int("nodesCount", config.NodesCount, "The number of nodes")
+	nodesTotalWeightPtr :=
+		flag.Int("nodesTotalWeight", config.NodesTotalWeight, "The total weight of nodes")
+	zipfParameterPtr :=
+		flag.Float64("zipfParameter", config.ZipfParameter, "The zipf's parameter")
+	messageWeightThresholdPtr :=
+		flag.Float64("messageWeightThreshold", config.MessageWeightThreshold, "The messageWeightThreshold of confirmed messages")
+	tipsCountPtr :=
+		flag.Int("tipsCount", config.TipsCount, "The tips count for a message")
+	weakTipsRatioPtr :=
+		flag.Float64("weakTipsRatio", config.WeakTipsRatio, "The ratio of weak tips")
+	tsaPtr :=
+		flag.String("tsa", config.TSA, "The tip selection algorithm")
+	tpsPtr :=
+		flag.Int("tps", config.TPS, "the tips per seconds")
+	decelerationFactorPtr :=
+		flag.Int("decelerationFactor", config.DecelerationFactor, "The factor to control the speed in the simulation")
+	consensusMonitorTickPtr :=
+		flag.Int("consensusMonitorTick", config.ConsensusMonitorTick, "The tick to monitor the consensus, in milliseconds")
+	doubleSpendDelayPtr :=
+		flag.Int("doubleSpendDelay", config.DoubleSpendDelay, "Delay for issuing double spend transactions. (Seconds)")
+	relevantValidatorWeightPtr :=
+		flag.Int("releventValidatorWeight", config.RelevantValidatorWeight, "The node whose weight * RelevantValidatorWeight <= largestWeight will not issue messages")
+	payloadLoss :=
+		flag.Float64("payloadLoss", config.PayloadLoss, "The payload loss percentage")
+	minDelay :=
+		flag.Int("minDelay", config.MinDelay, "The minimum network delay in ms")
+	maxDelay :=
+		flag.Int("maxDelay", config.MaxDelay, "The maximum network delay in ms")
+	deltaURTS :=
+		flag.Float64("deltaURTS", config.DeltaURTS, "in seconds, reference: https://iota.cafe/t/orphanage-with-restricted-urts/1199")
+	simulationStopThreshold :=
+		flag.Float64("simulationStopThreshold", config.SimulationStopThreshold, "Stop the simulation when >= SimulationStopThreshold * NodesCount have reached the same opinion")
+	simulationTarget :=
+		flag.String("simulationTarget", config.SimulationTarget, "The simulation target, CT: Confirmation Time, DS: Double Spending")
+	resultDirPtr :=
+		flag.String("resultDir", config.ResultDir, "Directory where the results will be stored")
+	imif :=
+		flag.String("IMIF", config.IMIF, "Inter Message Issuing Function for time delay between activity messages: poisson or uniform")
+	randomnessWS :=
+		flag.Float64("WattsStrogatzRandomness", config.RandomnessWS, "WattsStrogatz randomness parameter")
+	neighbourCountWS :=
+		flag.Int("WattsStrogatzNeighborCount", config.NeighbourCountWS, "Number of neighbors node is connected to in WattsStrogatz network topology")
+	adversaryDelays :=
+		flag.String("adversaryDelays", "", "Delays in ms of adversary nodes, eg '50 100 200'")
+	adversaryTypes :=
+		flag.String("adversaryType", "", "Defines attack strategy, one of the following: 'shift', 'same'")
+	adversaryMana :=
+		flag.String("adversaryMana", "", "Adversary nodes mana in %, e.g. '10 10' or 'random' if adversary nodes should be selected randomly")
+
+	// Parse the flags
+	flag.Parse()
+
+	// Update the configuration parameters
+	config.NodesCount = *nodesCountPtr
+	config.NodesTotalWeight = *nodesTotalWeightPtr
+	config.ZipfParameter = *zipfParameterPtr
+	config.MessageWeightThreshold = *messageWeightThresholdPtr
+	config.TipsCount = *tipsCountPtr
+	config.WeakTipsRatio = *weakTipsRatioPtr
+	config.TSA = *tsaPtr
+	config.TPS = *tpsPtr
+	config.DecelerationFactor = *decelerationFactorPtr
+	config.ConsensusMonitorTick = *consensusMonitorTickPtr
+	config.RelevantValidatorWeight = *relevantValidatorWeightPtr
+	config.DoubleSpendDelay = *doubleSpendDelayPtr
+	config.PayloadLoss = *payloadLoss
+	config.MinDelay = *minDelay
+	config.MaxDelay = *maxDelay
+	config.DeltaURTS = *deltaURTS
+	config.SimulationStopThreshold = *simulationStopThreshold
+	config.SimulationTarget = *simulationTarget
+	config.ResultDir = *resultDirPtr
+	config.IMIF = *imif
+	config.RandomnessWS = *randomnessWS
+	config.NeighbourCountWS = *neighbourCountWS
+
+	if *adversaryDelays != "" {
+		config.AdversaryDelays = parseStrToInt(*adversaryDelays)
+	}
+	if *adversaryTypes != "" {
+		config.AdversaryTypes = parseStrToInt(*adversaryTypes)
+	}
+	if *adversaryMana != "" {
+		config.AdversaryMana = parseStrToFloat64(*adversaryMana)
+	}
+
+	//TODO make sure three above have the same length
+
+	log.Info("Current configuration:")
+	log.Info("NodesCount: ", config.NodesCount)
+	log.Info("NodesTotalWeight: ", config.NodesTotalWeight)
+	log.Info("ZipfParameter: ", config.ZipfParameter)
+	log.Info("MessageWeightThreshold: ", config.MessageWeightThreshold)
+	log.Info("TipsCount: ", config.TipsCount)
+	log.Info("WeakTipsRatio: ", config.WeakTipsRatio)
+	log.Info("TSA: ", config.TSA)
+	log.Info("TPS: ", config.TPS)
+	log.Info("DecelerationFactor: ", config.DecelerationFactor)
+	log.Info("ConsensusMonitorTick: ", config.ConsensusMonitorTick)
+	log.Info("RelevantValidatorWeight: ", config.RelevantValidatorWeight)
+	log.Info("DoubleSpendDelay: ", config.DoubleSpendDelay)
+	log.Info("PayloadLoss: ", config.PayloadLoss)
+	log.Info("MinDelay: ", config.MinDelay)
+	log.Info("MaxDelay: ", config.MaxDelay)
+	log.Info("DeltaURTS:", config.DeltaURTS)
+	log.Info("SimulationStopThreshold:", config.SimulationStopThreshold)
+	log.Info("SimulationTarget:", config.SimulationTarget)
+	log.Info("ResultDir:", config.ResultDir)
+	log.Info("IMIF: ", config.IMIF)
+	log.Info("WattsStrogatzRandomness: ", config.RandomnessWS)
+	log.Info("WattsStrogatzNeighborCount: ", config.NeighbourCountWS)
+	log.Info("AdversaryDelays: ", config.AdversaryDelays)
+	log.Info("AdversaryTypes: ", config.AdversaryTypes)
+	log.Info("AdversaryMana: ", config.AdversaryMana)
+
+}
+
+func parseStrToInt(strList string) []int {
+	split := strings.Split(strList, " ")
+	parsed := make([]int, len(split))
+	for i, elem := range split {
+		num, _ := strconv.Atoi(elem)
+		parsed[i] = num
+	}
+	return parsed
+}
+
+func parseStrToFloat64(strList string) []float64 {
+	split := strings.Split(strList, " ")
+	parsed := make([]float64, len(split))
+	for i, elem := range split {
+		num, _ := strconv.ParseFloat(elem, 64)
+		parsed[i] = num
+	}
+	return parsed
+}

--- a/simulation/parser.go
+++ b/simulation/parser.go
@@ -63,7 +63,7 @@ func ParseFlags() {
 	adversaryMana :=
 		flag.String("adversaryMana", "", "Adversary nodes mana in %, e.g. '10 10' or 'random' if adversary nodes should be selected randomly")
 	adversaryErrorThreshold :=
-		flag.Float64("payloadLoss", config.AdversaryErrorThreshold, "The error threshold of q - percentage of mana held by adversary")
+		flag.Float64("adversaryErrorThreshold", config.AdversaryErrorThreshold, "The error threshold of q - percentage of mana held by adversary")
 
 	// Parse the flags
 	flag.Parse()


### PR DESCRIPTION
PR covers asdversary analysis tootls:
 - introduces 4 new parameters: AdversaryDelays, AdversaryTypes, AdversaryMana, AdversaryErrorThreshold 
They are taken into consideration only for `SimulationTarget` == 'DS'
List provided for adversaryTypes is corresponding to adgersary groups that will be created, it allows for max 3 elements - one per color. Each group can have custom delay and target mana percentage (% value, max, or min).
`AdversaryTypes`:
 - 0 - honest node behavior, after sending colored message
 - 1 - node will shift opinion to second largest AW
 - 2 - node keeps the same opinon 
`AdversaryMana`:
 - (0,100) - adversary group will be created from nodes that have provided mana % togheter (with error up to `AdversaryErrorThreshold`)
 - 0 - adversary group will have only one node with minimum mana
 - 1 -  adversary group will have only one node with maximum mana

